### PR TITLE
queue: add common test suite and homogeneize behavior.

### DIFF
--- a/queue/amqp.go
+++ b/queue/amqp.go
@@ -283,7 +283,7 @@ type AMQPJobIter struct {
 func (i *AMQPJobIter) Next() (*Job, error) {
 	d, ok := <-i.c
 	if !ok {
-		return nil, nil
+		return nil, ErrAlreadyClosed
 	}
 
 	return fromDelivery(&d), nil

--- a/queue/amqp_test.go
+++ b/queue/amqp_test.go
@@ -1,13 +1,10 @@
 package queue
 
 import (
-	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/mgo.v2/bson"
 )
 
 const amqpURL = "amqp://guest:guest@localhost:5672/"
@@ -17,153 +14,25 @@ func TestAMQPSuite(t *testing.T) {
 }
 
 type AMQPSuite struct {
-	suite.Suite
-	broker Broker
+	QueueSuite
 }
 
-func (s *AMQPSuite) SetupSuite() {
+func (s *AMQPSuite) SetupTest() {
 	assert := assert.New(s.T())
 	b, err := NewAMQPBroker(amqpURL)
 	assert.NoError(err)
-	s.broker = b
+	s.Broker = b
 }
 
-func (s *AMQPSuite) TearDownSuite() {
+func (s *AMQPSuite) TearDownTest() {
 	assert := assert.New(s.T())
-	assert.NoError(s.broker.Close())
+	assert.NoError(s.Broker.Close())
 }
 
-func (s *AMQPSuite) TestPublishAndConsume() {
-	assert := assert.New(s.T())
+func TestNewAMQPBroker_bad_url(t *testing.T) {
+	assert := assert.New(t)
 
-	q, err := s.broker.Queue(bson.NewObjectId().Hex())
-	assert.NoError(err)
-
-	job := NewJob()
-	job.Encode(true)
-	err = q.Publish(job)
-	assert.NoError(err)
-
-	for i := 0; i < 100; i++ {
-		job := NewJob()
-		job.Encode(i)
-		err = q.Publish(job)
-		assert.NoError(err)
-	}
-
-	i, err := q.Consume()
-	assert.NoError(err)
-
-	retrievedJob, err := i.Next()
-	assert.NoError(err)
-	assert.Nil(retrievedJob.Ack())
-
-	var payload bool
-	err = retrievedJob.Decode(&payload)
-	assert.NoError(err)
-	assert.True(payload)
-
-	assert.Equal(job.ID, retrievedJob.ID)
-	assert.Equal(job.Priority, retrievedJob.Priority)
-	assert.Equal(job.Timestamp.Second(), retrievedJob.Timestamp.Second())
-
-	for k := 0; k < 100; k++ {
-		j, err := i.Next()
-		assert.NoError(err)
-		if j == nil {
-			break
-		}
-
-		assert.NoError(j.Ack())
-		var payload int
-		assert.NoError(j.Decode(&payload))
-		assert.Equal(k, payload)
-	}
-
-	assert.NoError(i.Close())
-}
-
-func (s *AMQPSuite) TestDelayed() {
-	assert := assert.New(s.T())
-
-	q, err := s.broker.Queue(bson.NewObjectId().Hex())
-	assert.NoError(err)
-
-	job := NewJob()
-	job.Encode("hello")
-	err = q.PublishDelayed(job, 1*time.Second)
-	assert.NoError(err)
-
-	i, err := q.Consume()
-	assert.NoError(err)
-
-	start := time.Now()
-	var since time.Duration
-	for {
-		j, err := i.Next()
-		assert.NoError(err)
-		if j == nil {
-			<-time.After(300 * time.Millisecond)
-			continue
-		}
-
-		since = time.Since(start)
-
-		var payload string
-		assert.NoError(j.Decode(&payload))
-		assert.Equal("hello", payload)
-		break
-	}
-
-	assert.True(since >= 1*time.Second)
-}
-
-func (s *AMQPSuite) TestTransaction_Error() {
-	assert := assert.New(s.T())
-
-	q, err := s.broker.Queue(bson.NewObjectId().Hex())
-	assert.NoError(err)
-
-	err = q.Transaction(func(qu Queue) error {
-		job := NewJob()
-		assert.NoError(job.Encode("goodbye"))
-		assert.NoError(qu.Publish(job))
-		return errors.New("foo")
-	})
+	b, err := NewAMQPBroker("badurl")
 	assert.Error(err)
-
-	i, err := q.Consume()
-	assert.NoError(err)
-	go func() {
-		j, err := i.Next()
-		assert.NoError(err)
-		assert.Nil(j)
-	}()
-	<-time.After(50 * time.Millisecond)
-	assert.NoError(i.Close())
-}
-
-func (s *AMQPSuite) TestTransaction() {
-	assert := assert.New(s.T())
-
-	q, err := s.broker.Queue(bson.NewObjectId().Hex())
-	assert.NoError(err)
-
-	err = q.Transaction(func(q Queue) error {
-		job := NewJob()
-		assert.NoError(job.Encode("hello"))
-		assert.NoError(q.Publish(job))
-		return nil
-	})
-	assert.NoError(err)
-
-	iter, err := q.Consume()
-	assert.NoError(err)
-	j, err := iter.Next()
-	assert.NoError(err)
-	assert.NotNil(j)
-	var payload string
-	assert.NoError(j.Decode(&payload))
-	assert.Equal("hello", payload)
-	assert.NoError(iter.Close())
+	assert.Nil(b)
 }

--- a/queue/beanstalk_test.go
+++ b/queue/beanstalk_test.go
@@ -2,11 +2,9 @@ package queue
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/mgo.v2/bson"
 )
 
 func TestBeanstalkSuite(t *testing.T) {
@@ -14,107 +12,18 @@ func TestBeanstalkSuite(t *testing.T) {
 }
 
 type BeanstalkSuite struct {
-	suite.Suite
-	broker Broker
+	QueueSuite
 }
 
 func (s *BeanstalkSuite) SetupSuite() {
 	assert := assert.New(s.T())
 	b, err := NewBeanstalkBroker("127.0.0.1:11300")
 	assert.NoError(err)
-	s.broker = b
+	s.Broker = b
+	s.TxNotSupported = true
 }
 
 func (s *BeanstalkSuite) TearDownSuite() {
 	assert := assert.New(s.T())
-	assert.NoError(s.broker.Close())
-}
-
-func (s *BeanstalkSuite) TestPublishAndConsume() {
-	assert := assert.New(s.T())
-
-	q, err := s.broker.Queue(bson.NewObjectId().Hex())
-	assert.NoError(err)
-
-	job := NewJob()
-	job.Encode(true)
-	err = q.Publish(job)
-	assert.NoError(err)
-
-	for i := 0; i < 100; i++ {
-		job := NewJob()
-		job.Encode(i)
-		err = q.Publish(job)
-		assert.NoError(err)
-	}
-
-	i, err := q.Consume()
-	assert.NoError(err)
-
-	retrievedJob, err := i.Next()
-	assert.NoError(err)
-	assert.NoError(retrievedJob.Ack())
-
-	var payload bool
-	err = retrievedJob.Decode(&payload)
-	assert.NoError(err)
-	assert.True(payload)
-
-	assert.Equal(job.tag, retrievedJob.tag)
-	assert.Equal(job.Priority, retrievedJob.Priority)
-	assert.Equal(job.Timestamp.Second(), retrievedJob.Timestamp.Second())
-
-	for k := 0; k < 100; k++ {
-		j, err := i.Next()
-		assert.NoError(err)
-		if j == nil {
-			break
-		}
-
-		assert.NoError(j.Ack())
-		var payload int
-		assert.NoError(j.Decode(&payload))
-		assert.Equal(k, payload)
-	}
-
-	_, err = i.Next()
-	assert.Error(err)
-
-	err = i.Close()
-	assert.NoError(err)
-}
-
-func (s *BeanstalkSuite) TestDelayed() {
-	assert := assert.New(s.T())
-
-	q, err := s.broker.Queue(bson.NewObjectId().Hex())
-	assert.NoError(err)
-
-	job := NewJob()
-	job.Encode("hello")
-	err = q.PublishDelayed(job, 1*time.Second)
-	assert.NoError(err)
-
-	i, err := q.Consume()
-	assert.NoError(err)
-
-	start := time.Now()
-	var since time.Duration
-	for {
-		j, err := i.Next()
-		assert.NoError(err)
-		if j == nil {
-			<-time.After(300 * time.Millisecond)
-			continue
-		}
-
-		since = time.Since(start)
-
-		var payload string
-		assert.NoError(j.Decode(&payload))
-		assert.Equal("hello", payload)
-		break
-	}
-
-	assert.True(since >= 1*time.Second)
+	assert.NoError(s.Broker.Close())
 }

--- a/queue/common.go
+++ b/queue/common.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"errors"
+	"io"
 	"time"
 )
 
@@ -13,7 +14,11 @@ const (
 	PriorityLow    Priority = 0
 )
 
-var ErrEmptyJob = errors.New("invalid empty job")
+var (
+	ErrAlreadyClosed  = errors.New("already closed")
+	ErrEmptyJob       = errors.New("invalid empty job")
+	ErrTxNotSupported = errors.New("transactions not supported")
+)
 
 type Broker interface {
 	Queue(string) (Queue, error)
@@ -30,6 +35,9 @@ type Queue interface {
 }
 
 type JobIter interface {
+	// Next returns the next Job in the iterator. It should block until the
+	// job becomes available. Returns ErrAlreadyClosed if the iterator is
+	// closed.
 	Next() (*Job, error)
-	Close() error
+	io.Closer
 }

--- a/queue/common_test.go
+++ b/queue/common_test.go
@@ -1,0 +1,345 @@
+package queue
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+var testRand *rand.Rand
+
+func init() {
+	testRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+func newName() string {
+	return fmt.Sprintf("queue_tests_%d", testRand.Int())
+}
+
+type QueueSuite struct {
+	suite.Suite
+	r rand.Rand
+
+	TxNotSupported bool
+	Broker         Broker
+}
+
+func (s *QueueSuite) TestConsume_empty() {
+	assert := assert.New(s.T())
+
+	qName := newName()
+	q, err := s.Broker.Queue(qName)
+	assert.NoError(err)
+	assert.NotNil(q)
+
+	iter, err := q.Consume()
+	assert.NoError(err)
+	assert.NotNil(iter)
+
+	assert.NoError(iter.Close())
+}
+
+func (s *QueueSuite) TestJobIter_Next_empty() {
+	assert := assert.New(s.T())
+
+	qName := newName()
+	q, err := s.Broker.Queue(qName)
+	assert.NoError(err)
+	assert.NotNil(q)
+
+	iter, err := q.Consume()
+	assert.NoError(err)
+	assert.NotNil(iter)
+
+	done := s.checkNextClosed(iter)
+	assert.NoError(iter.Close())
+	<-done
+}
+
+func (s *QueueSuite) TestJob_Reject_no_requeue() {
+	assert := assert.New(s.T())
+
+	qName := newName()
+	q, err := s.Broker.Queue(qName)
+	assert.NoError(err)
+	assert.NotNil(q)
+
+	j := NewJob()
+	err = j.Encode(1)
+	assert.NoError(err)
+
+	err = q.Publish(j)
+	assert.NoError(err)
+
+	iter, err := q.Consume()
+	assert.NoError(err)
+	assert.NotNil(iter)
+
+	j, err = iter.Next()
+	assert.NoError(err)
+	assert.NotNil(j)
+
+	j.Reject(false)
+
+	done := s.checkNextClosed(iter)
+	<-time.After(50 * time.Millisecond)
+	assert.NoError(iter.Close())
+	<-done
+}
+
+func (s *QueueSuite) TestJob_Reject_requeue() {
+	assert := assert.New(s.T())
+
+	qName := newName()
+	q, err := s.Broker.Queue(qName)
+	assert.NoError(err)
+	assert.NotNil(q)
+
+	j := NewJob()
+	err = j.Encode(1)
+	assert.NoError(err)
+
+	err = q.Publish(j)
+	assert.NoError(err)
+
+	iter, err := q.Consume()
+	assert.NoError(err)
+	assert.NotNil(iter)
+
+	j, err = iter.Next()
+	assert.NoError(err)
+	assert.NotNil(j)
+
+	j.Reject(true)
+
+	j, err = iter.Next()
+	assert.NoError(err)
+	assert.NotNil(j)
+
+	assert.NoError(iter.Close())
+}
+
+func (s *QueueSuite) TestPublish_nil() {
+	assert := assert.New(s.T())
+
+	qName := newName()
+	q, err := s.Broker.Queue(qName)
+	assert.NoError(err)
+	assert.NotNil(q)
+
+	err = q.Publish(nil)
+	assert.Equal(ErrEmptyJob, err)
+}
+
+func (s *QueueSuite) TestPublish_empty() {
+	assert := assert.New(s.T())
+
+	qName := newName()
+	q, err := s.Broker.Queue(qName)
+	assert.NoError(err)
+	assert.NotNil(q)
+
+	err = q.Publish(&Job{})
+	assert.Equal(ErrEmptyJob, err)
+}
+
+func (s *QueueSuite) TestPublishDelayed_nil() {
+	assert := assert.New(s.T())
+
+	qName := newName()
+	q, err := s.Broker.Queue(qName)
+	assert.NoError(err)
+	assert.NotNil(q)
+
+	err = q.PublishDelayed(nil, time.Second)
+	assert.Equal(ErrEmptyJob, err)
+}
+
+func (s *QueueSuite) TestPublishDelayed_empty() {
+	assert := assert.New(s.T())
+
+	qName := newName()
+	q, err := s.Broker.Queue(qName)
+	assert.NoError(err)
+	assert.NotNil(q)
+
+	err = q.PublishDelayed(&Job{}, time.Second)
+	assert.Equal(ErrEmptyJob, err)
+}
+
+func (s *QueueSuite) TestPublishAndConsume_immediate_ack() {
+	assert := assert.New(s.T())
+
+	qName := newName()
+	q, err := s.Broker.Queue(qName)
+	assert.NoError(err)
+	assert.NotNil(q)
+
+	var (
+		ids        []string
+		priorities []Priority
+		timestamps []time.Time
+	)
+	for i := 0; i < 100; i++ {
+		j := NewJob()
+		err = j.Encode(i)
+		assert.NoError(err)
+		err = q.Publish(j)
+		assert.NoError(err)
+		ids = append(ids, j.ID)
+		priorities = append(priorities, j.Priority)
+		timestamps = append(timestamps, j.Timestamp)
+	}
+
+	iter, err := q.Consume()
+	assert.NoError(err)
+	assert.NotNil(iter)
+
+	for i := 0; i < 100; i++ {
+		j, err := iter.Next()
+		assert.NoError(err)
+		assert.NoError(j.Ack())
+
+		var payload int
+		assert.NoError(j.Decode(&payload))
+		assert.Equal(i, payload)
+
+		assert.Equal(ids[i], j.ID)
+		assert.Equal(priorities[i], j.Priority)
+		assert.Equal(timestamps[i].Unix(), j.Timestamp.Unix())
+	}
+
+	done := s.checkNextClosed(iter)
+	assert.NoError(iter.Close())
+	<-done
+}
+
+func (s *QueueSuite) TestDelayed() {
+	assert := assert.New(s.T())
+
+	qName := newName()
+	q, err := s.Broker.Queue(qName)
+	assert.NoError(err)
+	assert.NotNil(q)
+
+	j := NewJob()
+	err = j.Encode("hello")
+	assert.NoError(err)
+	err = q.PublishDelayed(j, 1*time.Second)
+	assert.NoError(err)
+
+	iter, err := q.Consume()
+	assert.NoError(err)
+
+	start := time.Now()
+	var since time.Duration
+	for {
+		j, err := iter.Next()
+		assert.NoError(err)
+		if j == nil {
+			<-time.After(300 * time.Millisecond)
+			continue
+		}
+
+		since = time.Since(start)
+
+		var payload string
+		assert.NoError(j.Decode(&payload))
+		assert.Equal("hello", payload)
+		break
+	}
+
+	assert.True(since >= 1*time.Second)
+}
+
+func (s *QueueSuite) TestTransaction_Error() {
+	if s.TxNotSupported {
+		s.T().Skip("transactions not supported")
+	}
+
+	assert := assert.New(s.T())
+
+	qName := newName()
+	q, err := s.Broker.Queue(qName)
+	assert.NoError(err)
+	assert.NotNil(q)
+
+	err = q.Transaction(func(qu Queue) error {
+		job := NewJob()
+		assert.NoError(job.Encode("goodbye"))
+		assert.NoError(qu.Publish(job))
+		return errors.New("foo")
+	})
+	assert.Error(err)
+
+	i, err := q.Consume()
+	assert.NoError(err)
+	done := s.checkNextClosed(i)
+	<-time.After(50 * time.Millisecond)
+	assert.NoError(i.Close())
+	<-done
+}
+
+func (s *QueueSuite) TestTransaction() {
+	if s.TxNotSupported {
+		s.T().Skip("transactions not supported")
+	}
+
+	assert := assert.New(s.T())
+
+	qName := newName()
+	q, err := s.Broker.Queue(qName)
+	assert.NoError(err)
+	assert.NotNil(q)
+
+	err = q.Transaction(func(q Queue) error {
+		job := NewJob()
+		assert.NoError(job.Encode("hello"))
+		assert.NoError(q.Publish(job))
+		return nil
+	})
+	assert.NoError(err)
+
+	iter, err := q.Consume()
+	assert.NoError(err)
+	j, err := iter.Next()
+	assert.NoError(err)
+	assert.NotNil(j)
+	var payload string
+	assert.NoError(j.Decode(&payload))
+	assert.Equal("hello", payload)
+	assert.NoError(iter.Close())
+}
+
+func (s *QueueSuite) TestTransaction_not_supported() {
+	assert := assert.New(s.T())
+
+	if !s.TxNotSupported {
+		s.T().Skip("transactions supported")
+	}
+
+	qName := newName()
+	q, err := s.Broker.Queue(qName)
+	assert.NoError(err)
+	assert.NotNil(q)
+
+	err = q.Transaction(nil)
+	assert.Equal(ErrTxNotSupported, err)
+}
+
+func (s *QueueSuite) checkNextClosed(iter JobIter) chan struct{} {
+	assert := assert.New(s.T())
+
+	done := make(chan struct{})
+	go func() {
+		j, err := iter.Next()
+		assert.Equal(ErrAlreadyClosed, err)
+		assert.Nil(j)
+		done <- struct{}{}
+	}()
+	return done
+}

--- a/queue/job.go
+++ b/queue/job.go
@@ -29,6 +29,8 @@ type Acknowledger interface {
 	Reject(requeue bool) error
 }
 
+// NewJob creates a new Job with default values, a new unique ID and current
+// timestamp.
 func NewJob() *Job {
 	return &Job{
 		ID:          bson.NewObjectId().Hex(),


### PR DESCRIPTION
* add common QueueSuite.

* JobIter Next() now blocks until there is a new job or the iter
  is closed. This was already the behavior for amqp, but not for
  beanstalk and memory.

* JobIter Next() now returns ErrAlreadyClosed if it was already.

* Queue Publish now returns ErrEmptyJob if the job is nil or empty
  (this was the case for amqp and beanstalk, but not for memory).

* memory implementation now supports Job Reject(true).

* Transaction returns error if the callback returns error. This
  was already the behavior for amqp, but not for memory.

* beanstalk now returns ErrTxNotSupported for Transaction.