### PR TITLE
Implement a way to establish database connections

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -1,0 +1,168 @@
+package database
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	_ "github.com/lib/pq"
+	"srcd.works/framework.v0/configurable"
+)
+
+// DatabaseConfig describes the configuration of the database parameters used
+// to establish a connection with it.
+type DatabaseConfig struct {
+	configurable.BasicConfiguration
+
+	// Username of the database user.
+	Username string `envconfig:"dbuser" default:"testing"`
+	// Password of the database user.
+	Password string `envconfig:"dbpass" default:"testing"`
+	// Port used to establish connection with the database.
+	Port int `envconfig:"dbport" default:"5432"`
+	// Host to establish connection with the database.
+	Host string `envconfig:"dbhost" default:"0.0.0.0"`
+	// Name of the database to connect to.
+	Name string `envconfig:"dbname" default:"testing"`
+	// SSLMode used to specify the way of using SSL in the connection.
+	SSLMode SSLMode `envconfig:"dbsslmode" default:"disable"`
+	// AppName is the name of the app using the connection.
+	AppName string `envconfig="dbappname"`
+	// Timeout is the number time to consider a connection timed out.
+	Timeout time.Duration `envconfig:"dbtimeout" default:"30s"`
+}
+
+// DataSourceName returns the DSN string to connect to the database.
+func (c *DatabaseConfig) DataSourceName() (string, error) {
+	if c.Name == "" {
+		return "", fmt.Errorf("database: database name cannot be empty")
+	}
+
+	if c.Port <= 0 {
+		return "", fmt.Errorf("database: port is not valid")
+	}
+
+	if c.Host == "" {
+		return "", fmt.Errorf("database: host cannot be empty")
+	}
+
+	if c.Username == "" {
+		return "", fmt.Errorf("database: username cannot be empty")
+	}
+
+	if string(c.SSLMode) == "" {
+		c.SSLMode = Disable
+	}
+
+	ds := fmt.Sprintf(
+		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
+		c.Username,
+		c.Password,
+		c.Host,
+		c.Port,
+		c.Name,
+		c.SSLMode,
+	)
+
+	if c.AppName != "" {
+		ds += fmt.Sprintf("&application_name=%s", c.AppName)
+	}
+
+	if c.Timeout >= 1*time.Second {
+		ds += fmt.Sprintf("&connect_timeout=%d", int(c.Timeout.Seconds()))
+	}
+
+	return ds, nil
+}
+
+// SSLMode provides different levels of protection against attacks.
+// Check https://www.postgresql.org/docs/9.1/static/libpq-ssl.html
+type SSLMode string
+
+const (
+	// Disable disables the SSL.
+	Disable SSLMode = "disable"
+	// Allow enables the SSL only if the server insists on it.
+	Allow SSLMode = "allow"
+	// Prefer enables the SSL but only if the server supports it.
+	Prefer SSLMode = "prefer"
+	// Require ensures SSL is used but does not check the network is secure.
+	Require SSLMode = "require"
+	// VerifyCA ensures SSL is used and the connection is established with a
+	// trusted server.
+	VerifyCA SSLMode = "verify-ca"
+	// VerifyFull ensures SSL is used and the connection is established with
+	// the specified server.
+	VerifyFull SSLMode = "verify-full"
+)
+
+// DefaultConfig is the default database configuration, whose values come from
+// environment variables with default values if the environment variables are
+// not provided to the value used in a testing setup.
+// - CONFIG_DBUSER: database username
+// - CONFIG_DBPASS: database user password
+// - CONFIG_DBHOST: database host
+// - CONFIG_DBPORT: database port
+// - CONFIG_DBNAME: database name
+// - CONFIG_DBSSLMODE: ssl mode to use
+// - CONFIG_DBAPPNAME: application name
+// - CONFIG_DBTIMEOUT: connection timeout
+var DefaultConfig = new(DatabaseConfig)
+
+// ErrNoConfig is returned when there is an attempt of getting a databsse
+// connection with no configuration.
+var ErrNoConfig = errors.New("database: can't get database with no configuration")
+
+// Get returns a database connection with the configuration resultant of
+// applying the given configfuncs to the config.
+// Passing a nil configuration will result in an error.
+func Get(config *DatabaseConfig, configurators ...ConfigFunc) (*sql.DB, error) {
+	if config == nil {
+		return nil, ErrNoConfig
+	}
+
+	for _, c := range configurators {
+		config = c(config)
+	}
+
+	ds, err := config.DataSourceName()
+	if err != nil {
+		return nil, err
+	}
+
+	return sql.Open("postgres", ds)
+}
+
+// Default returns a database connection established using the default
+// configuration.
+func Default(configurators ...ConfigFunc) (*sql.DB, error) {
+	return Get(DefaultConfig, configurators...)
+}
+
+// Must will panic if the given error is not nil and, otherwise, will return
+// the database connection.
+func Must(db *sql.DB, err error) *sql.DB {
+	if err != nil {
+		panic(err)
+	}
+	return db
+}
+
+// ConfigFunc is a function that will receive a database configuration and
+// return a new one with some parameters changed.
+type ConfigFunc func(*DatabaseConfig) *DatabaseConfig
+
+// WithName returns a ConfigFunc that will change the database name of the
+// received database config to the one given.
+func WithName(name string) ConfigFunc {
+	return func(c *DatabaseConfig) *DatabaseConfig {
+		cfg := *c
+		cfg.Name = name
+		return &cfg
+	}
+}
+
+func init() {
+	configurable.InitConfig(DefaultConfig)
+}

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,0 +1,178 @@
+package database
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	defaults "github.com/mcuadros/go-defaults"
+	"github.com/stretchr/testify/require"
+)
+
+func invalid() *DatabaseConfig {
+	return new(DatabaseConfig)
+}
+
+func mkConf(fn func(*DatabaseConfig)) *DatabaseConfig {
+	c := new(DatabaseConfig)
+	defaults.SetDefaults(c)
+	fn(c)
+	return c
+}
+
+func TestDataSourceName(t *testing.T) {
+	require := require.New(t)
+
+	var defaultConf = new(DatabaseConfig)
+	defaults.SetDefaults(defaultConf)
+
+	cases := []struct {
+		name     string
+		conf     *DatabaseConfig
+		expected string
+		err      bool
+	}{
+		{
+			"default",
+			defaultConf,
+			"postgres://testing:testing@0.0.0.0:5432/testing?sslmode=disable&connect_timeout=30",
+			false,
+		},
+		{
+			"empty",
+			&DatabaseConfig{},
+			"",
+			true,
+		},
+		{
+			"no name",
+			mkConf(func(c *DatabaseConfig) {
+				c.Name = ""
+			}),
+			"",
+			true,
+		},
+		{
+			"no port",
+			mkConf(func(c *DatabaseConfig) {
+				c.Port = 0
+			}),
+			"",
+			true,
+		},
+		{
+			"no host",
+			mkConf(func(c *DatabaseConfig) {
+				c.Host = ""
+			}),
+			"",
+			true,
+		},
+		{
+			"no user",
+			mkConf(func(c *DatabaseConfig) {
+				c.Username = ""
+			}),
+			"",
+			true,
+		},
+		{
+			"no sslmode",
+			mkConf(func(c *DatabaseConfig) {
+				c.SSLMode = SSLMode("")
+			}),
+			"postgres://testing:testing@0.0.0.0:5432/testing?sslmode=disable&connect_timeout=30",
+			false,
+		},
+		{
+			"custom no timeout",
+			&DatabaseConfig{
+				Username: "foo",
+				Password: "bar",
+				Host:     "baz",
+				Port:     1337,
+				Name:     "qux",
+				SSLMode:  VerifyFull,
+			},
+			"postgres://foo:bar@baz:1337/qux?sslmode=verify-full",
+			false,
+		},
+		{
+			"custom app name",
+			mkConf(func(c *DatabaseConfig) {
+				c.AppName = "myapp"
+			}),
+			"postgres://testing:testing@0.0.0.0:5432/testing?sslmode=disable&application_name=myapp&connect_timeout=30",
+			false,
+		},
+		{
+			"custom timeout",
+			mkConf(func(c *DatabaseConfig) {
+				c.Timeout = 1 * time.Second
+			}),
+			"postgres://testing:testing@0.0.0.0:5432/testing?sslmode=disable&connect_timeout=1",
+			false,
+		},
+	}
+
+	for _, c := range cases {
+		ds, err := c.conf.DataSourceName()
+		if c.err {
+			require.NotNil(err, c.name)
+		} else {
+			require.Equal(c.expected, ds, c.name)
+		}
+	}
+}
+
+func TestGet(t *testing.T) {
+	require := require.New(t)
+
+	_, err := Get(nil)
+	require.Equal(ErrNoConfig, err)
+
+	db, err := Get(DefaultConfig)
+	require.Nil(err)
+	require.NotNil(db)
+	close(t, db)
+
+	db, err = Get(DefaultConfig, WithName("Foo"))
+	require.Nil(err)
+	require.NotNil(db)
+	close(t, db)
+
+	_, err = Get(DefaultConfig, WithName(""))
+	require.NotNil(err)
+}
+
+func TestDefault(t *testing.T) {
+	require := require.New(t)
+	db, err := Default()
+	require.Nil(err)
+	require.NotNil(db)
+	close(t, db)
+
+	_, err = Default(WithName(""))
+	require.NotNil(err)
+}
+
+func TestMust(t *testing.T) {
+	require := require.New(t)
+
+	require.NotPanics(func() {
+		close(t, Must(Default()))
+	})
+
+	require.Panics(func() {
+		close(t, Must(Get(nil)))
+	})
+}
+
+func TestWithName(t *testing.T) {
+	cfg := WithName("foo")(DefaultConfig)
+	require.Equal(t, "foo", cfg.Name)
+}
+
+func close(t *testing.T, db *sql.DB) {
+	require.Nil(t, db.Close())
+}


### PR DESCRIPTION
# Database connection

This PR implements a generic way to establish a connection with the database with as minimal configuration as possible, but open for the possibility of being configured if needed.
It is assumed all connections are postgres connections. If this is not the case, please say so, so I can add a database agnostic way of doing this.

### Integration with kallax

The only integration we need with kallax in framework is this, being able to get a database connection, as framework will not be aware of any of the concrete models and so it won't be able to act as `Container` used in domain and construct instances of stores. This is to be done in the packages implementing kallax models.

All that is needed to create a new kallax store is the database connection, so this should be enough for our needs.

### Usage

In most cases:
```go
database.Must(database.Default())
```
(or avoid the `Must` if you want to get a database connection _and_ the error, instead of panicking if some error happens)

When you want to use the default config but for some reason you need some other database name:

```go
database.Must(database.Default(database.WithName("foo")))
```
(Only `WithName` configurator is implemented right now, if you think we may need to implement more, just say so)

It can be configured programmatically using `DatabaseConfig` or using environment variables.