### PR TITLE
Implement a retry queue using rabbit dead-letter feature

### DIFF
--- a/queue/common.go
+++ b/queue/common.go
@@ -78,6 +78,8 @@ type Queue interface {
 	Transaction(TxCallback) error
 	// Consume returns a JobIter for the queue.
 	Consume() (JobIter, error)
+	// RepublishBuried republish all jobs in the buried queue to the main one
+	RepublishBuried() error
 }
 
 // JobIter represents an iterator over a set of Jobs.


### PR DESCRIPTION
This PR implements a Buried or Retry queue for both memoryQueue and AMQPQueue. All jobs with a timeout without receiving Ack/Reject or a Reject with requeue = False will be added to the secondary retry queue (using RabbitMQ dead-letter feature for AMQPQueue). 

Please note that jobs Rejected with requeue = True will be added to the normal queue again and (as RabbitMQ does) at the top. So any dependency that want to use this feature (like Borges) will need to switch that boolean on the calls to Reject. 

Jobs in the buried queue can be republished with the new Queue interface method Queue.RepublishBuried().

Caveats:

- There is a workaround on RepublishBuried of waiting 50msecs between republishings (but I don't think RepublishBuried is very performance sensitive) Without it, a call to Next() on the main queue too fast after RepublishBuried() would block forever. I'm starting to suspect some nasty sync problem in the amqp module dependency but I can't be sure. The workaround has worked for some million of very fast test iterations but since I can't pinpoint the specific problem causing this I can't be absolutely sure that the workaround will always work; if there are new occurrences of the problem before we find the root cause increasing the timeout should reduce or fix it. On real world usage I don't think this will be a problem (even without the workaround) because Next() wont   be called within nanoseconds of calling RepublishBuried,  but I'm still unhappy about this.

- For the same reason jobs published with PublishDelayed don't support the buried queue feature.