### PR TITLE
Next should not wait for ack of previous job

### DIFF
--- a/queue/common.go
+++ b/queue/common.go
@@ -76,17 +76,20 @@ type Queue interface {
 	PublishDelayed(*Job, time.Duration) error
 	// Transaction executes the passed TxCallback inside a transaction.
 	Transaction(TxCallback) error
-	// Consume returns a JobIter for the queue.
-	Consume() (JobIter, error)
+	// Consume returns a JobIter for the queue.  Ir receives the minimum
+	// number of undelivered jobs the iterator will allow at any given
+	// time (see the Acknowledger interface).
+	Consume(advertisedWindow int) (JobIter, error)
 	// RepublishBuried republish all jobs in the buried queue to the main one
 	RepublishBuried() error
 }
 
 // JobIter represents an iterator over a set of Jobs.
 type JobIter interface {
-	// Next returns the next Job in the iterator. It should block until the
-	// job becomes available. Returns ErrAlreadyClosed if the iterator is
-	// closed.
+	// Next returns the next Job in the iterator. It should block until
+	// the job becomes available or while too many undelivered jobs has
+	// been already returned (see the argument to Queue.Consume). Returns
+	// ErrAlreadyClosed if the iterator is closed.
 	Next() (*Job, error)
 	io.Closer
 }

--- a/queue/common_test.go
+++ b/queue/common_test.go
@@ -83,7 +83,8 @@ func (s *QueueSuite) TestConsume_empty() {
 	assert.NoError(err)
 	assert.NotNil(q)
 
-	iter, err := q.Consume()
+	awnd := 1
+	iter, err := q.Consume(awnd)
 	assert.NoError(err)
 	assert.NotNil(iter)
 
@@ -98,7 +99,8 @@ func (s *QueueSuite) TestJobIter_Next_empty() {
 	assert.NoError(err)
 	assert.NotNil(q)
 
-	iter, err := q.Consume()
+	awnd := 1
+	iter, err := q.Consume(awnd)
 	assert.NoError(err)
 	assert.NotNil(iter)
 
@@ -122,7 +124,8 @@ func (s *QueueSuite) TestJob_Reject_no_requeue() {
 	err = q.Publish(j)
 	assert.NoError(err)
 
-	iter, err := q.Consume()
+	awnd := 1
+	iter, err := q.Consume(awnd)
 	assert.NoError(err)
 	assert.NotNil(iter)
 
@@ -154,7 +157,8 @@ func (s *QueueSuite) TestJob_Reject_requeue() {
 	err = q.Publish(j)
 	assert.NoError(err)
 
-	iter, err := q.Consume()
+	awnd := 1
+	iter, err := q.Consume(awnd)
 	assert.NoError(err)
 	assert.NotNil(iter)
 
@@ -244,7 +248,8 @@ func (s *QueueSuite) TestPublishAndConsume_immediate_ack() {
 		timestamps = append(timestamps, j.Timestamp)
 	}
 
-	iter, err := q.Consume()
+	awnd := 1
+	iter, err := q.Consume(awnd)
 	assert.NoError(err)
 	assert.NotNil(iter)
 
@@ -270,13 +275,14 @@ func (s *QueueSuite) TestPublishAndConsume_immediate_ack() {
 func (s *QueueSuite) TestConsumersCanShareJobIteratorConcurrently() {
 	assert := assert.New(s.T())
 	const (
-		nConsumers int = 2
+		nConsumers int = 10
 		nJobs      int = nConsumers
+		awnd       int = nConsumers
 	)
 	queue := s.newQueueWithJobs(nJobs)
 
 	// the iter will be shared by all consumers
-	iter, err := queue.Consume()
+	iter, err := queue.Consume(awnd)
 	assert.NoError(err)
 	assert.NotNil(iter)
 
@@ -341,7 +347,8 @@ func (s *QueueSuite) TestDelayed() {
 	err = q.PublishDelayed(j, 1*time.Second)
 	assert.NoError(err)
 
-	iter, err := q.Consume()
+	awnd := 1
+	iter, err := q.Consume(awnd)
 	assert.NoError(err)
 
 	start := time.Now()
@@ -385,7 +392,8 @@ func (s *QueueSuite) TestTransaction_Error() {
 	})
 	assert.Error(err)
 
-	i, err := q.Consume()
+	awnd := 1
+	i, err := q.Consume(awnd)
 	assert.NoError(err)
 	done := s.checkNextClosed(i)
 	<-time.After(50 * time.Millisecond)
@@ -413,7 +421,8 @@ func (s *QueueSuite) TestTransaction() {
 	})
 	assert.NoError(err)
 
-	iter, err := q.Consume()
+	awnd := 1
+	iter, err := q.Consume(awnd)
 	assert.NoError(err)
 	j, err := iter.Next()
 	assert.NoError(err)
@@ -463,7 +472,8 @@ func (s *QueueSuite) TestRetryQueue() {
 	assert.NoError(err)
 
 	// 2: consume and reject them.
-	iterMain, err := q.Consume()
+	awnd := 1
+	iterMain, err := q.Consume(awnd)
 	assert.NoError(err)
 	assert.NotNil(iterMain)
 

--- a/queue/job.go
+++ b/queue/job.go
@@ -28,8 +28,10 @@ type Job struct {
 	tag          uint64
 }
 
-// Acknowledger represents the object in charge of acknowledgement management for a
-// job.
+// Acknowledger represents the object in charge of acknowledgement
+// management for a job.  When a job is acknowledged using any of the
+// functions in this interface, it will be considered delivered by the
+// queue.
 type Acknowledger interface {
 	// Ack is called when the Job has finished.
 	Ack() error

--- a/queue/memory.go
+++ b/queue/memory.go
@@ -83,8 +83,8 @@ func (q *memoryQueue) Transaction(txcb TxCallback) error {
 	return nil
 }
 
-// Consume returns a JobIter for the jobs in the queue.
-func (q *memoryQueue) Consume() (JobIter, error) {
+// Consume implements Queue.  MemoryQueues have infinite advertised window.
+func (q *memoryQueue) Consume(_ int) (JobIter, error) {
 	return &memoryJobIter{q: q, RWMutex: &q.RWMutex}, nil
 }
 

--- a/queue/memory_test.go
+++ b/queue/memory_test.go
@@ -39,7 +39,8 @@ func (s *MemorySuite) TestIntegration() {
 		assert.NoError(err)
 	}
 
-	iter, err := q.Consume()
+	awnd := 0 // ignored by memory brokers
+	iter, err := q.Consume(awnd)
 	assert.NoError(err)
 
 	retrievedJob, err := iter.Next()


### PR DESCRIPTION
Fix https://github.com/src-d/framework/issues/19.

This patch adds flow control capabilities to JobIter by adding a new advertised window argument to `Queue.Consume` (see [Flow Control](https://en.wikipedia.org/wiki/Flow_control_(data)) ).  By tuning the advertised window to the number of workers fetching jobs from a JobIter, you will be able to run them in parallel.

The memory implementation of Queue has infinite advertised window to keep things simple.

It also adds a new common test for the fix: TestConsumersCanShareJobIteratorConcurrently.