### PR TITLE
lock: initial version of local and etcd lockers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ services:
   - rabbitmq
   - postgresql
 
+before_install:
+  - export ETCD_VERSION=v3.2.0
+  - wget https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz
+  - tar xvzf etcd-${ETCD_VERSION}-linux-amd64.tar.gz
+  - sudo mv etcd-${ETCD_VERSION}-linux-amd64/etcd /usr/local/bin/
+
 install:
   - make dependencies
 

--- a/README.md
+++ b/README.md
@@ -7,3 +7,16 @@
 * **configurable** standarizes the way to create configuration containers.
 * **database** package provides access to SQL databases.
 * **queue** provides access to message brokers.
+
+## Development
+
+Run tests with:
+
+  go test -v ./...
+
+Tests require the following services running:
+
+* PostgreSQL
+* RabbitMQ
+
+They also need the `etcd` binary present in `PATH`.

--- a/lock/common.go
+++ b/lock/common.go
@@ -1,0 +1,87 @@
+// Package lock provides implementations for cancellable and distributed locks.
+package lock
+
+import (
+	"net/url"
+	"time"
+
+	"gopkg.in/src-d/go-errors.v0"
+)
+
+var (
+	ErrUnsupportedService      = errors.NewKind("unsupported service: %s")
+	ErrInvalidConnectionString = errors.NewKind("invalid connection string: %s")
+	ErrCanceled                = errors.NewKind("context canceled")
+	ErrAlreadyClosed           = errors.NewKind("already closed")
+)
+
+// Services is a registry of all supported services by name. Map key is the
+// service name, which will be looked up in URIs scheme.
+var Services map[string]func(string) (Service, error)
+
+func init() {
+	Services = make(map[string]func(string) (Service, error))
+}
+
+// New creates a service given a connection string.
+func New(connstr string) (Service, error) {
+	u, err := url.Parse(connstr)
+	if err != nil {
+		return nil, ErrInvalidConnectionString.Wrap(err, "invalid URL")
+	}
+
+	name := u.Scheme
+	srvf, ok := Services[name]
+	if !ok {
+		return nil, ErrUnsupportedService.New(name)
+	}
+
+	return srvf(connstr)
+}
+
+// SessionConfig holds configuration for a locking session.
+type SessionConfig struct {
+	// TTL is the time-to-live of all locks in a session. A lock operation times
+	// out when the TTL expires. A lock is lost whenever it cannot be kept alive
+	// inside the TTL. For example, a lock in a distributed lock service maintains
+	// a keep alive heartbeat, once a heartbeat is not received for more than
+	// the specified TTL, it must be assumed that the lock is no longer held.
+	TTL time.Duration
+}
+
+// Service is a locking service.
+type Service interface {
+	// NewSession creates a new locking session with the given configuration.
+	// An error is returned if the session cannot be created (e.g. invalid
+	// configuration, connection cannot be established to remote service).
+	NewSession(*SessionConfig) (Session, error)
+	// Close closes the service and releases any resources held by it.
+	// If it is called more than once, ErrAlreadyClosed is returned.
+	Close() error
+}
+
+// Session is a locking session that can be reused to get multiple locks.
+// Multiple actors should use different sessions.
+type Session interface {
+	// NewService creates a NewService for the given id. Lockers returned for the
+	// same id on different sessions are mutually exclusive.
+	NewLocker(id string) Locker
+	// Close closes the session and releases any resources held by it.
+	// If it is called more than once, ErrAlreadyClosed is returned.
+	Close() error
+}
+
+// Locker is the interface to a lock.
+type Locker interface {
+	// Context can be used to cancel the operation (e.g. with a timeout).
+	// If it succeeds, it returns a cancel channel. Otherwise, it returns an
+	// error. The cancel channel is closed whenever the lock is not held anymore.
+	// Note that the lock might be lost before calling to Unlock.
+	Lock() (<-chan struct{}, error)
+	// Unlock releases the lock. It might return an error if the lock could not
+	// be released cleanly. However, this error is merely informative and no
+	// action needs to be taken. Locking services must ensure that a lock that
+	// failed to be released cleanly expires at some point (e.g. after session
+	// TTL expires).
+	Unlock() error
+}

--- a/lock/common_test.go
+++ b/lock/common_test.go
@@ -1,0 +1,367 @@
+package lock
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type LockSuite struct {
+	suite.Suite
+	ConnectionString string
+}
+
+func (s *LockSuite) NewService() Service {
+	assert := s.Assert()
+	srv, err := New(s.ConnectionString)
+	assert.NoError(err)
+	return srv
+}
+
+func (s *LockSuite) TestLockUnlockSingleLockNoConcurrency() {
+	assert := s.Assert()
+	niter := 100
+	id := "mylock"
+	service := s.NewService()
+	cfg := &SessionConfig{TTL: 1 * time.Second}
+	session, err := service.NewSession(cfg)
+	assert.NoError(err)
+	for i := 0; i < niter; i++ {
+		locker := session.NewLocker(id)
+		s.testLockUnlock(locker)
+	}
+
+	err = service.Close()
+	assert.NoError(err)
+}
+
+func (s *LockSuite) TestLockTimeout() {
+	assert := s.Assert()
+
+	service := s.NewService()
+	cfg := &SessionConfig{
+		TTL: time.Millisecond * 500,
+	}
+	id := "mylock-" + s.T().Name()
+
+	session1, err := service.NewSession(cfg)
+	assert.NoError(err)
+	locker1 := session1.NewLocker(id)
+
+	session2, err := service.NewSession(cfg)
+	assert.NoError(err)
+	locker2 := session2.NewLocker(id)
+
+	_, err = locker1.Lock()
+	assert.NoError(err)
+	_, err = locker2.Lock()
+	assert.Error(err)
+	assert.True(ErrCanceled.Is(err))
+
+	err = service.Close()
+	assert.NoError(err)
+}
+
+func (s *LockSuite) TestDoubleClose() {
+	assert := s.Assert()
+	service := s.NewService()
+	err := service.Close()
+	assert.NoError(err)
+	err = service.Close()
+	assert.Error(err)
+	assert.True(ErrAlreadyClosed.Is(err))
+
+	service = s.NewService()
+	cfg := &SessionConfig{}
+	session, err := service.NewSession(cfg)
+	assert.NoError(err)
+	err = session.Close()
+	assert.NoError(err)
+	err = session.Close()
+	assert.Error(err)
+	assert.True(ErrAlreadyClosed.Is(err))
+	err = service.Close()
+	assert.NoError(err)
+	err = service.Close()
+	assert.Error(err)
+	assert.True(ErrAlreadyClosed.Is(err))
+}
+
+func (s *LockSuite) TestLockUnlockMultipleLocksNoConcurrency() {
+	assert := s.Assert()
+	niter := 100
+	id := "mylock"
+	service := s.NewService()
+	cfg := &SessionConfig{TTL: 1 * time.Second}
+	session, err := service.NewSession(cfg)
+	assert.NoError(err)
+	for i := 0; i < niter; i++ {
+		locker := session.NewLocker(id + strconv.Itoa(i))
+		s.testLockUnlock(locker)
+	}
+
+	err = session.Close()
+	assert.NoError(err)
+	err = service.Close()
+	assert.NoError(err)
+}
+
+func (s *LockSuite) TestLockUnlockSingleLockConcurrentNoTimeout() {
+	assert := s.Assert()
+	niter := 100
+	id := "mylock"
+	service := s.NewService()
+	cfg := &SessionConfig{}
+	counter := 0
+	wg := &sync.WaitGroup{}
+	wg.Add(niter)
+	for i := 0; i < niter; i++ {
+		go func() {
+			f := func() {
+				counter++
+			}
+			session, err := service.NewSession(cfg)
+			assert.NoError(err)
+			locker := session.NewLocker(id)
+			s.testLockUnlockConcurrent(locker, f, false)
+			err = session.Close()
+			assert.NoError(err)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(niter, counter)
+	err := service.Close()
+	assert.NoError(err)
+}
+
+func (s *LockSuite) TestLockUnlockSingleLockConcurrentTimeout() {
+	assert := s.Assert()
+	niter := 100
+	id := "mylock"
+	service := s.NewService()
+	cfg := &SessionConfig{TTL: time.Second * 2}
+	counter := 0
+	wg := &sync.WaitGroup{}
+	wg.Add(niter)
+	for i := 0; i < niter; i++ {
+		go func() {
+			f := func() {
+				counter++
+			}
+			session, err := service.NewSession(cfg)
+			assert.NoError(err)
+			locker := session.NewLocker(id)
+			s.testLockUnlockConcurrent(locker, f, true)
+			err = session.Close()
+			assert.NoError(err)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(niter, counter)
+	err := service.Close()
+	assert.NoError(err)
+}
+
+func (s *LockSuite) TestLockUnlockMultipleLocksConcurrentNoTimeout() {
+	assert := s.Assert()
+	niter := 1000
+	id := "mylock"
+	service := s.NewService()
+	cfg := &SessionConfig{}
+	wg := &sync.WaitGroup{}
+	wg.Add(niter)
+	for i := 0; i < niter; i++ {
+		go func(i int) {
+			f := func() {}
+			session, err := service.NewSession(cfg)
+			assert.NoError(err)
+			locker := session.NewLocker(id + strconv.Itoa(i))
+			s.testLockUnlockConcurrent(locker, f, false)
+			err = session.Close()
+			assert.NoError(err)
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+	err := service.Close()
+	assert.NoError(err)
+}
+
+func (s *LockSuite) TestLockUnlockMultipleLocksConcurrentNoTimeoutSingleSession() {
+	assert := s.Assert()
+	niter := 1000
+	id := "mylock"
+	service := s.NewService()
+	cfg := &SessionConfig{}
+	session, err := service.NewSession(cfg)
+	assert.NoError(err)
+	wg := &sync.WaitGroup{}
+	wg.Add(niter)
+	for i := 0; i < niter; i++ {
+		go func(i int) {
+			f := func() {}
+			locker := session.NewLocker(id + strconv.Itoa(i))
+			s.testLockUnlockConcurrent(locker, f, false)
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+	err = session.Close()
+	assert.NoError(err)
+	err = service.Close()
+	assert.NoError(err)
+}
+
+func (s *LockSuite) TestLockUnlockMultipleLocksConcurrentTimeout() {
+	assert := s.Assert()
+	niter := 1000
+	id := "mylock"
+	service := s.NewService()
+	cfg := &SessionConfig{TTL: time.Second * 2}
+	wg := &sync.WaitGroup{}
+	wg.Add(niter)
+	for i := 0; i < niter; i++ {
+		go func(i int) {
+			f := func() {}
+			session, err := service.NewSession(cfg)
+			assert.NoError(err)
+			locker := session.NewLocker(id + strconv.Itoa(i))
+			s.testLockUnlockConcurrent(locker, f, true)
+			err = session.Close()
+			assert.NoError(err)
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+	err := service.Close()
+	assert.NoError(err)
+}
+
+func (s *LockSuite) testLockUnlockConcurrent(locker Locker, f func(), hasTimeout bool) {
+	assert := s.Assert()
+	t := s.T()
+	lostLocks := 0
+	for {
+		cancel, err := locker.Lock()
+		if hasTimeout {
+			if err != nil {
+				if ErrCanceled.Is(err) {
+					continue
+				}
+
+				assert.True(ErrCanceled.Is(err))
+				break
+			}
+		} else {
+			assert.NoError(err)
+			if err != nil {
+				break
+			}
+		}
+
+		done := false
+		select {
+		case <-cancel:
+			assert.Fail("lost lock")
+			lostLocks++
+		default:
+			f()
+			done = true
+		}
+		err = locker.Unlock()
+		assert.NoError(err)
+		if done {
+			if lostLocks > 0 {
+				t.Logf("lock lost %d times", lostLocks)
+			}
+			break
+		}
+
+		if lostLocks >= 3 {
+			assert.Fail("too many lost locks")
+			break
+		}
+	}
+}
+
+func (s *LockSuite) testLockUnlock(locker Locker) {
+	assert := s.Assert()
+	_, err := locker.Lock()
+	assert.NoError(err)
+	err = locker.Unlock()
+	assert.NoError(err)
+}
+
+func Example() {
+	service, err := New("local:")
+	if err != nil {
+		panic(err)
+	}
+
+	cfg := &SessionConfig{TTL: time.Second * 10}
+
+	id := "mylock"
+	counter := 0
+	niter := 1000
+	wg := &sync.WaitGroup{}
+	wg.Add(niter)
+	for i := 0; i < niter; i++ {
+		go func() {
+			session, err := service.NewSession(cfg)
+			if err != nil {
+				panic(err)
+			}
+
+			lock := session.NewLocker(id)
+			cancel, err := lock.Lock()
+			if err != nil {
+				panic(err)
+			}
+
+			select {
+			case <-cancel:
+				panic("lost lock")
+			default:
+				counter++
+			}
+
+			err = lock.Unlock()
+			if err != nil {
+				panic(err)
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	fmt.Println(counter)
+	//Output: 1000
+}
+
+func TestNewUnsupportedService(t *testing.T) {
+	require := require.New(t)
+	srv, err := New("unsupported:")
+	require.Error(err)
+	require.True(ErrUnsupportedService.Is(err))
+	require.Nil(srv)
+}
+
+func TestNewInvalidConnectionString(t *testing.T) {
+	require := require.New(t)
+	srv, err := New(":")
+	require.Error(err)
+	require.True(ErrInvalidConnectionString.Is(err))
+	require.Nil(srv)
+}

--- a/lock/etcd.go
+++ b/lock/etcd.go
@@ -1,0 +1,223 @@
+package lock
+
+import (
+	"fmt"
+	"math"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
+	"golang.org/x/net/context"
+)
+
+const ServiceEtcd = "etcd"
+
+func init() {
+	Services[ServiceEtcd] = NewEtcd
+}
+
+// NewEtcd creates a new locking service based on etcd given a connection string.
+// The connection string has the following form:
+//
+//   etcd:<endpoints>[?<opt1>=<val1>&<opt2>=<val2>]
+//
+// For example:
+//
+//   etcd:http//foo:8888,http://bar:9999?dial-timeout=2s&reject-old-cluster=true
+//
+// Valid options are:
+//
+//   - auto-sync-interval (time duration)
+//   - dial-timeout (time duration)
+//   - dial-keep-alive-time (time duration)
+//   - dial-keep-alive-timeout (time duration)
+//   - username (string)
+//   - password (string)
+//   - reject-old-cluster (boolean)
+//
+// For further information about each option, check the etcd godocs at:
+// https://godoc.org/github.com/coreos/etcd/clientv3#Config
+func NewEtcd(connstr string) (Service, error) {
+	cfg, err := parseEtcdConnectionstring(connstr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &etcdSrv{
+		cfg: cfg,
+		m:   &sync.Mutex{},
+	}, nil
+}
+
+func parseEtcdConnectionstring(connstr string) (cfg clientv3.Config, err error) {
+	u, err := url.Parse(connstr)
+	if err != nil {
+		return cfg, ErrInvalidConnectionString.Wrap(err, "invalid URL")
+	}
+
+	if u.Scheme != ServiceEtcd {
+		return cfg, ErrUnsupportedService.New(u.Scheme)
+	}
+
+	if u.Opaque == "" {
+		return cfg, ErrInvalidConnectionString.New("URI must be opaque")
+	}
+
+	cfg.Endpoints = strings.Split(u.Opaque, ",")
+	for key, vals := range u.Query() {
+		val := vals[len(vals)-1]
+		switch key {
+		case "auto-sync-interval":
+			cfg.AutoSyncInterval, err = time.ParseDuration(val)
+			if err != nil {
+				return cfg, ErrInvalidConnectionString.Wrap(err, key)
+			}
+		case "dial-timeout":
+			cfg.DialTimeout, err = time.ParseDuration(val)
+			if err != nil {
+				return cfg, ErrInvalidConnectionString.Wrap(err, key)
+			}
+		case "dial-keep-alive-time":
+			cfg.DialKeepAliveTime, err = time.ParseDuration(val)
+			if err != nil {
+				return cfg, ErrInvalidConnectionString.Wrap(err, key)
+			}
+		case "dial-keep-alive-timeout":
+			cfg.DialKeepAliveTimeout, err = time.ParseDuration(val)
+			if err != nil {
+				return cfg, ErrInvalidConnectionString.Wrap(err, key)
+			}
+		case "username":
+			cfg.Username = val
+		case "password":
+			cfg.Password = val
+		case "reject-old-cluster":
+			cfg.RejectOldCluster, err = strconv.ParseBool(val)
+			if err != nil {
+				return cfg, ErrInvalidConnectionString.Wrap(err, key)
+			}
+		default:
+			return cfg, ErrInvalidConnectionString.New(fmt.Sprintf("invalid option: %s", key))
+		}
+	}
+
+	return cfg, nil
+}
+
+type etcdSrv struct {
+	cfg    clientv3.Config
+	client *clientv3.Client
+	m      *sync.Mutex
+	closed bool
+}
+
+func (s *etcdSrv) connect() error {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.client == nil {
+		client, err := clientv3.New(s.cfg)
+		if err != nil {
+			return err
+		}
+
+		s.client = client
+	}
+
+	return nil
+}
+
+func (s *etcdSrv) NewSession(cfg *SessionConfig) (Session, error) {
+	if err := s.connect(); err != nil {
+		return nil, err
+	}
+
+	ttl := int(math.Ceil(cfg.TTL.Seconds()))
+	session, err := concurrency.NewSession(s.client, concurrency.WithTTL(ttl))
+	if err != nil {
+		return nil, err
+	}
+
+	return &etcdSess{
+		cfg:     cfg,
+		session: session,
+	}, nil
+}
+
+func (l *etcdSrv) Close() error {
+	if l.closed {
+		return ErrAlreadyClosed.New()
+	}
+
+	defer func() { l.closed = true }()
+
+	if l.client == nil {
+		return nil
+	}
+
+	return l.client.Close()
+}
+
+type etcdSess struct {
+	cfg     *SessionConfig
+	session *concurrency.Session
+}
+
+func (s *etcdSess) NewLocker(id string) Locker {
+	return &etcdLock{
+		cfg:     s.cfg,
+		session: s.session,
+		mutex:   concurrency.NewMutex(s.session, id),
+	}
+}
+
+func (s *etcdSess) Close() error {
+	session := s.session
+	if session == nil {
+		return ErrAlreadyClosed.New()
+	}
+
+	s.session = nil
+	return session.Close()
+}
+
+type etcdLock struct {
+	cfg     *SessionConfig
+	session *concurrency.Session
+	mutex   *concurrency.Mutex
+}
+
+func (l *etcdLock) Lock() (<-chan struct{}, error) {
+	ctx := context.Background()
+
+	ttl := l.cfg.TTL
+	if ttl > 0 {
+		if ttl < time.Second {
+			ttl = time.Second
+		}
+
+		ctx, _ = context.WithTimeout(ctx, ttl)
+	}
+
+	if err := l.mutex.Lock(ctx); err != nil {
+		if isContextDeadlineExceededError(err) {
+			return nil, ErrCanceled.Wrap(err)
+		}
+
+		return nil, err
+	}
+
+	return ctx.Done(), nil
+}
+
+func (m *etcdLock) Unlock() error {
+	return m.mutex.Unlock(context.TODO())
+}
+
+func isContextDeadlineExceededError(err error) bool {
+	return strings.Contains(err.Error(), "context deadline exceeded")
+}

--- a/lock/etcd_linux_test.go
+++ b/lock/etcd_linux_test.go
@@ -1,0 +1,53 @@
+package lock
+
+import (
+	"syscall"
+	"time"
+)
+
+// +build linux
+
+func (s *EtcdLockSuite) TestLockExpire() {
+	assert := s.Assert()
+
+	id := "mylock"
+	service := s.NewService()
+	session, err := service.NewSession(&SessionConfig{
+		TTL: 2 * time.Second,
+	})
+	assert.NoError(err)
+
+	locker := session.NewLocker(id)
+	ch, err := locker.Lock()
+	assert.NoError(err)
+
+	err = s.cmd.Process.Signal(syscall.SIGSTOP)
+	assert.NoError(err)
+	<-ch
+	err = s.cmd.Process.Signal(syscall.SIGCONT)
+	assert.NoError(err)
+
+	err = service.Close()
+	assert.NoError(err)
+}
+
+func (s *EtcdLockSuite) TestSessionError() {
+	assert := s.Assert()
+
+	service := s.NewService()
+
+	err := s.cmd.Process.Signal(syscall.SIGSTOP)
+	assert.NoError(err)
+
+	session, err := service.NewSession(&SessionConfig{
+		TTL: 2 * time.Second,
+	})
+	assert.Error(err)
+	assert.Nil(session)
+
+	err = s.cmd.Process.Signal(syscall.SIGCONT)
+	assert.NoError(err)
+
+	err = service.Close()
+	assert.NoError(err)
+}

--- a/lock/etcd_test.go
+++ b/lock/etcd_test.go
@@ -1,0 +1,253 @@
+package lock
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/src-d/go-errors.v0"
+)
+
+type EtcdLockSuite struct {
+	LockSuite
+	Endpoints []string
+	etcdPath  string
+	dataDir   string
+	cmd       *exec.Cmd
+}
+
+func TestEtcdLock(t *testing.T) {
+	suite.Run(t, new(EtcdLockSuite))
+}
+
+func (s *EtcdLockSuite) SetupSuite() {
+	t := s.T()
+	etcdPath, err := exec.LookPath("etcd")
+	if err != nil {
+		t.Skip("etcd not available in PATH")
+	}
+	s.etcdPath = etcdPath
+}
+
+func (s *EtcdLockSuite) SetupTest() {
+	require := s.Require()
+
+	dataDir, err := ioutil.TempDir("", "etcd-data_")
+	require.NoError(err)
+	s.dataDir = dataDir
+
+	endpoint := "http://" + freeAddress()
+	peerEndpoint := "http://" + freeAddress()
+	s.Endpoints = []string{endpoint}
+
+	cmd := exec.Command(
+		s.etcdPath,
+		"--name=node1",
+		"--data-dir="+dataDir,
+		"--initial-advertise-peer-urls", peerEndpoint,
+		"--listen-peer-urls", peerEndpoint,
+		"--advertise-client-urls", endpoint,
+		"--listen-client-urls", endpoint,
+		"--initial-cluster", "node1="+peerEndpoint,
+	)
+	s.cmd = cmd
+	s.cmd.Stderr = os.Stderr
+	s.cmd.Stdout = ioutil.Discard
+	err = s.cmd.Start()
+	require.NoError(err)
+
+	s.ConnectionString = fmt.Sprintf("etcd:%s?dial-timeout=2s", strings.Join(s.Endpoints, ","))
+
+	retries := 0
+	for {
+		srv, err := NewEtcd(s.ConnectionString)
+		if err == nil {
+			_ = srv.Close()
+			break
+		}
+
+		retries++
+		if retries >= 10 {
+			require.Fail("cannot connect to etcd", err)
+			break
+		}
+	}
+}
+
+func (s *EtcdLockSuite) TearDownTest() {
+	assert := s.Assert()
+
+	go s.cmd.Wait()
+
+	err := s.cmd.Process.Kill()
+	assert.NoError(err)
+
+	err = os.RemoveAll(s.dataDir)
+	assert.NoError(err)
+}
+
+func (s *EtcdLockSuite) TestUnavailableEtcd() {
+	assert := s.Assert()
+
+	service, err := New("etcd:https://localhost:19191?dial-timeout=2s")
+	assert.NoError(err)
+
+	_, err = service.NewSession(&SessionConfig{})
+	assert.Error(err)
+	err = service.Close()
+	assert.NoError(err)
+}
+
+func (s *EtcdLockSuite) TestSmallTTL() {
+	assert := s.Assert()
+	// etcd uses a ttl of at least 1 second
+	// so whenever we specify a ttl > 0, it should be fixed to 1 second or more
+	// instead of 0 (no timeout)
+	service := s.NewService()
+	cfg := &SessionConfig{
+		TTL: time.Millisecond * 1,
+	}
+	id := "mylock-" + s.T().Name()
+
+	session1, err := service.NewSession(cfg)
+	assert.NoError(err)
+	locker1 := session1.NewLocker(id)
+
+	session2, err := service.NewSession(cfg)
+	assert.NoError(err)
+	locker2 := session2.NewLocker(id)
+
+	_, err = locker1.Lock()
+	assert.NoError(err)
+	_, err = locker2.Lock()
+	assert.Error(err)
+	assert.True(ErrCanceled.Is(err))
+
+	err = service.Close()
+	assert.NoError(err)
+}
+
+func freeAddress() string {
+	// Ensure we get IPv6 address. etcd v2.3.0 on Travis with IPv6 fails.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic(err)
+	}
+	defer l.Close()
+	return l.Addr().String()
+}
+
+func TestNewEtcdParseError(t *testing.T) {
+	require := require.New(t)
+	srv, err := NewEtcd("local:")
+	require.Error(err)
+	require.True(ErrUnsupportedService.Is(err))
+	require.Nil(srv)
+}
+
+func TestParseEtcdConnectionstring(t *testing.T) {
+	require := require.New(t)
+	for _, tc := range []struct {
+		Input     string
+		Output    clientv3.Config
+		ErrorKind *errors.Kind
+	}{{
+		Input: "etcd:http://foo:8888",
+		Output: clientv3.Config{
+			Endpoints: []string{"http://foo:8888"},
+		},
+	}, {
+		Input: "etcd:http://foo:8888,http://bar:9999",
+		Output: clientv3.Config{
+			Endpoints: []string{"http://foo:8888", "http://bar:9999"},
+		},
+	}, {
+		Input: "etcd:http://foo:8888,http://bar:9999?dial-timeout=2s",
+		Output: clientv3.Config{
+			Endpoints:   []string{"http://foo:8888", "http://bar:9999"},
+			DialTimeout: 2 * time.Second,
+		},
+	}, {
+		Input: "etcd:http://foo:8888,http://bar:9999?dial-timeout=1s&dial-timeout=2s",
+		Output: clientv3.Config{
+			Endpoints:   []string{"http://foo:8888", "http://bar:9999"},
+			DialTimeout: 2 * time.Second,
+		},
+	}, {
+		Input:     "etcd:http://foo:8888,http://bar:9999?dial-timeout=invalid",
+		ErrorKind: ErrInvalidConnectionString,
+	}, {
+		Input: "etcd:http://foo:8888,http://bar:9999?auto-sync-interval=3s",
+		Output: clientv3.Config{
+			Endpoints:        []string{"http://foo:8888", "http://bar:9999"},
+			AutoSyncInterval: 3 * time.Second,
+		},
+	}, {
+		Input:     "etcd:http://foo:8888,http://bar:9999?auto-sync-interval=invalid",
+		ErrorKind: ErrInvalidConnectionString,
+	}, {
+		Input: "etcd:http://foo:8888,http://bar:9999?dial-keep-alive-time=4s",
+		Output: clientv3.Config{
+			Endpoints:         []string{"http://foo:8888", "http://bar:9999"},
+			DialKeepAliveTime: 4 * time.Second,
+		},
+	}, {
+		Input:     "etcd:http://foo:8888,http://bar:9999?dial-keep-alive-time=invalid",
+		ErrorKind: ErrInvalidConnectionString,
+	}, {
+		Input: "etcd:http://foo:8888,http://bar:9999?dial-keep-alive-timeout=5s",
+		Output: clientv3.Config{
+			Endpoints:            []string{"http://foo:8888", "http://bar:9999"},
+			DialKeepAliveTimeout: 5 * time.Second,
+		},
+	}, {
+		Input:     "etcd:http://foo:8888,http://bar:9999?dial-keep-alive-timeout=invalid",
+		ErrorKind: ErrInvalidConnectionString,
+	}, {
+		Input: "etcd:http://foo:8888,http://bar:9999?username=foo&password=bar",
+		Output: clientv3.Config{
+			Endpoints: []string{"http://foo:8888", "http://bar:9999"},
+			Username:  "foo",
+			Password:  "bar",
+		},
+	}, {
+		Input: "etcd:http://foo:8888,http://bar:9999?reject-old-cluster=true",
+		Output: clientv3.Config{
+			Endpoints:        []string{"http://foo:8888", "http://bar:9999"},
+			RejectOldCluster: true,
+		},
+	}, {
+		Input:     "etcd:http://foo:8888,http://bar:9999?reject-old-cluster=invalid",
+		ErrorKind: ErrInvalidConnectionString,
+	}, {
+		Input:     "etcd:http://foo:8888?invalid-key=true",
+		ErrorKind: ErrInvalidConnectionString,
+	}, {
+		Input:     "etcd://foo:8888?invalid-key=true",
+		ErrorKind: ErrInvalidConnectionString,
+	}, {
+		Input:     ":",
+		ErrorKind: ErrInvalidConnectionString,
+	}, {
+		Input:     "local:http://foo:8888",
+		ErrorKind: ErrUnsupportedService,
+	}} {
+		cfg, err := parseEtcdConnectionstring(tc.Input)
+		if tc.ErrorKind != nil {
+			require.Error(err, tc.Input)
+			require.True(tc.ErrorKind.Is(err), tc.Input)
+			continue
+		}
+
+		require.NoError(err, tc.Input)
+		require.Equal(tc.Output, cfg, tc.Input)
+	}
+}

--- a/lock/local.go
+++ b/lock/local.go
@@ -1,0 +1,183 @@
+package lock
+
+import (
+	"sync"
+	"time"
+)
+
+const ServiceLocal = "local"
+
+func init() {
+	Services[ServiceLocal] = func(string) (Service, error) {
+		return NewLocal(), nil
+	}
+}
+
+type localLock struct {
+	ch chan struct{}
+}
+
+func newLocalLock() *localLock {
+	l := &localLock{make(chan struct{}, 1)}
+	l.ch <- struct{}{}
+	return l
+}
+
+func (l *localLock) Lock(timeout time.Duration) bool {
+	if timeout == 0 {
+		<-l.ch
+		return true
+	}
+
+	select {
+	case _, ok := <-l.ch:
+		return ok
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func (l *localLock) Unlock() {
+	l.ch <- struct{}{}
+}
+
+func (l *localLock) Close() error {
+	if l.ch == nil {
+		return ErrAlreadyClosed.New()
+	}
+
+	close(l.ch)
+	l.ch = nil
+	return nil
+}
+
+type localSrv struct {
+	locks    map[string]*localLock
+	refCount map[string]int
+	m        *sync.Mutex
+	closed   bool
+}
+
+// NewLocal creates a new locking service that uses in-process locks. This can
+// be used whenever locking is relevant only to the local process.
+func NewLocal() Service {
+	return &localSrv{
+		locks:    map[string]*localLock{},
+		refCount: map[string]int{},
+		m:        &sync.Mutex{},
+	}
+}
+
+func (s *localSrv) NewSession(cfg *SessionConfig) (Session, error) {
+	return &localSess{
+		cfg: cfg,
+		srv: s,
+	}, nil
+}
+
+func (s *localSrv) Close() error {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.closed {
+		return ErrAlreadyClosed.New()
+	}
+
+	var err error
+	for _, lock := range s.locks {
+		cerr := lock.Close()
+		if cerr != nil && err == nil {
+			err = cerr
+		}
+	}
+
+	s.closed = true
+	return err
+}
+
+func (s *localSrv) getLock(id string) *localLock {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	lock, ok := s.locks[id]
+	if !ok {
+		lock = newLocalLock()
+		s.locks[id] = lock
+	}
+
+	s.refCount[id] = s.refCount[id] + 1
+	return lock
+}
+
+func (s *localSrv) freeLock(id string) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	c, ok := s.refCount[id]
+	c--
+	if c > 0 {
+		s.refCount[id] = c
+		return
+	}
+
+	if ok {
+		delete(s.refCount, id)
+	}
+
+	if lock, ok := s.locks[id]; ok {
+		_ = lock.Close()
+		delete(s.locks, id)
+	}
+}
+
+type localSess struct {
+	cfg    *SessionConfig
+	srv    *localSrv
+	closed bool
+}
+
+func (s *localSess) NewLocker(id string) Locker {
+	return &localLocker{id: id, sess: s}
+}
+
+func (s *localSess) Close() error {
+	if s.closed {
+		return ErrAlreadyClosed.New()
+	}
+
+	s.closed = true
+	return nil
+}
+
+type localLocker struct {
+	id     string
+	sess   *localSess
+	lock   *localLock
+	unlock chan struct{}
+}
+
+func (l *localLocker) Lock() (<-chan struct{}, error) {
+	lock := l.sess.srv.getLock(l.id)
+	ok := lock.Lock(l.sess.cfg.TTL)
+	if !ok {
+		l.sess.srv.freeLock(l.id)
+		return nil, ErrCanceled.New()
+	}
+
+	l.lock = lock
+	l.unlock = make(chan struct{})
+	return l.unlock, nil
+}
+
+func (l *localLocker) Unlock() error {
+	lock := l.lock
+	if lock == nil {
+		return nil
+	}
+
+	l.lock = nil
+	close(l.unlock)
+	lock.Unlock()
+	l.sess.srv.freeLock(l.id)
+	return nil
+}

--- a/lock/local_test.go
+++ b/lock/local_test.go
@@ -1,0 +1,100 @@
+package lock
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type LocalLockSuite struct {
+	LockSuite
+	Endpoints []string
+}
+
+func TestLocalLock(t *testing.T) {
+	suite.Run(t, new(LocalLockSuite))
+}
+
+func (s *LocalLockSuite) SetupTest() {
+	s.ConnectionString = "local:"
+}
+
+func TestInternalLocalLock(t *testing.T) {
+	require := require.New(t)
+
+	lock := newLocalLock()
+	for i := 0; i < 1000; i++ {
+		ok := lock.Lock(0)
+		require.True(ok)
+		lock.Unlock()
+	}
+
+	wg := &sync.WaitGroup{}
+	niter := 10000
+	wg.Add(niter)
+	counter := 0
+	for i := 0; i < niter; i++ {
+		go func() {
+			ok := lock.Lock(0)
+			require.True(ok)
+			counter++
+			lock.Unlock()
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	require.Equal(niter, counter)
+
+	niter = 10000
+	timeout := time.Millisecond * 1
+	wg.Add(niter)
+	counter = 0
+	for i := 0; i < niter; i++ {
+		go func() {
+			for {
+				ok := lock.Lock(timeout)
+				if !ok {
+					continue
+				}
+
+				counter++
+				lock.Unlock()
+				break
+			}
+
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	require.Equal(niter, counter)
+
+	niter = 100
+	timeout = time.Millisecond * 5
+	wg.Add(niter)
+	counter = 0
+	for i := 0; i < niter; i++ {
+		go func() {
+			for {
+				ok := lock.Lock(timeout)
+				if !ok {
+					continue
+				}
+
+				counter++
+				time.Sleep(time.Millisecond * 10)
+				lock.Unlock()
+				break
+			}
+
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	require.Equal(niter, counter)
+}


### PR DESCRIPTION
This package provides multiple locking services (local
and etcd). Others can be plugged in at runtime. Locking
services API provides semantics appropriate for distributed
lock services.
   
Each service can create sessions. Each actor in the system
has to use its own session. Each session can create Lockers
with arbitrary string IDs.
    
Registred locking services can be instantiated using New with a
URL-like connection string. For example:
    
      local:
    
or
    
      etcd:http://node1:8888,http://node2:9999,http://node3:9999?dial-timeout=2s
