### PR TITLE
lock: add Timeout to SessionConfig

### DIFF
--- a/lock/common.go
+++ b/lock/common.go
@@ -41,6 +41,9 @@ func New(connstr string) (Service, error) {
 
 // SessionConfig holds configuration for a locking session.
 type SessionConfig struct {
+	// Timeout is the timeout when acquiring a lock. Calls to Lock() on a Locker
+	// in the session will fail if the lock cannot be acquired before timeout.
+	Timeout time.Duration
 	// TTL is the time-to-live of all locks in a session. A lock operation times
 	// out when the TTL expires. A lock is lost whenever it cannot be kept alive
 	// inside the TTL. For example, a lock in a distributed lock service maintains

--- a/lock/common_test.go
+++ b/lock/common_test.go
@@ -28,7 +28,10 @@ func (s *LockSuite) TestLockUnlockSingleLockNoConcurrency() {
 	niter := 100
 	id := "mylock"
 	service := s.NewService()
-	cfg := &SessionConfig{TTL: 1 * time.Second}
+	cfg := &SessionConfig{
+		Timeout: 1 * time.Second,
+		TTL:     1 * time.Second,
+	}
 	session, err := service.NewSession(cfg)
 	assert.NoError(err)
 	for i := 0; i < niter; i++ {
@@ -45,7 +48,7 @@ func (s *LockSuite) TestLockTimeout() {
 
 	service := s.NewService()
 	cfg := &SessionConfig{
-		TTL: time.Millisecond * 500,
+		Timeout: time.Millisecond * 500,
 	}
 	id := "mylock-" + s.T().Name()
 

--- a/lock/etcd.go
+++ b/lock/etcd.go
@@ -194,13 +194,13 @@ type etcdLock struct {
 func (l *etcdLock) Lock() (<-chan struct{}, error) {
 	ctx := context.Background()
 
-	ttl := l.cfg.TTL
-	if ttl > 0 {
-		if ttl < time.Second {
-			ttl = time.Second
+	timeout := l.cfg.Timeout
+	if timeout > 0 {
+		if timeout < time.Second {
+			timeout = time.Second
 		}
 
-		ctx, _ = context.WithTimeout(ctx, ttl)
+		ctx, _ = context.WithTimeout(ctx, timeout)
 	}
 
 	if err := l.mutex.Lock(ctx); err != nil {
@@ -211,7 +211,7 @@ func (l *etcdLock) Lock() (<-chan struct{}, error) {
 		return nil, err
 	}
 
-	return ctx.Done(), nil
+	return l.session.Done(), nil
 }
 
 func (m *etcdLock) Unlock() error {

--- a/lock/etcd_test.go
+++ b/lock/etcd_test.go
@@ -64,7 +64,9 @@ func (s *EtcdLockSuite) SetupTest() {
 	err = s.cmd.Start()
 	require.NoError(err)
 
-	s.ConnectionString = fmt.Sprintf("etcd:%s?dial-timeout=2s", strings.Join(s.Endpoints, ","))
+	s.ConnectionString = fmt.Sprintf(
+		"etcd:%s?dial-timeout=2s&dial-keep-alive-timeout=2s",
+		strings.Join(s.Endpoints, ","))
 
 	retries := 0
 	for {
@@ -106,14 +108,14 @@ func (s *EtcdLockSuite) TestUnavailableEtcd() {
 	assert.NoError(err)
 }
 
-func (s *EtcdLockSuite) TestSmallTTL() {
+func (s *EtcdLockSuite) TestSmallTimeout() {
 	assert := s.Assert()
-	// etcd uses a ttl of at least 1 second
-	// so whenever we specify a ttl > 0, it should be fixed to 1 second or more
+	// etcd uses a timeout of at least 1 second
+	// so whenever we specify a timeout > 0, it should be fixed to 1 second or more
 	// instead of 0 (no timeout)
 	service := s.NewService()
 	cfg := &SessionConfig{
-		TTL: time.Millisecond * 1,
+		Timeout: time.Millisecond * 1,
 	}
 	id := "mylock-" + s.T().Name()
 

--- a/lock/local.go
+++ b/lock/local.go
@@ -59,7 +59,8 @@ type localSrv struct {
 }
 
 // NewLocal creates a new locking service that uses in-process locks. This can
-// be used whenever locking is relevant only to the local process.
+// be used whenever locking is relevant only to the local process. Local locks
+// are never lost, so TTL is ignored.
 func NewLocal() Service {
 	return &localSrv{
 		locks:    map[string]*localLock{},
@@ -158,7 +159,7 @@ type localLocker struct {
 
 func (l *localLocker) Lock() (<-chan struct{}, error) {
 	lock := l.sess.srv.getLock(l.id)
-	ok := lock.Lock(l.sess.cfg.TTL)
+	ok := lock.Lock(l.sess.cfg.Timeout)
 	if !ok {
 		l.sess.srv.freeLock(l.id)
 		return nil, ErrCanceled.New()


### PR DESCRIPTION
TTL parameter was incorrectly used for Timeout too.