### PR TITLE
do not return io.EOF when there are no more items

### DIFF
--- a/queue/memory.go
+++ b/queue/memory.go
@@ -1,7 +1,6 @@
 package queue
 
 import (
-	"io"
 	"sync"
 	"time"
 )
@@ -144,7 +143,7 @@ func (i *memoryJobIter) next() (*Job, error) {
 	i.Lock()
 	defer i.Unlock()
 	if len(i.q.jobs) <= i.q.idx {
-		return nil, io.EOF
+		return nil, nil
 	}
 	j := i.q.jobs[i.q.idx]
 	i.q.idx++

--- a/queue/memory_test.go
+++ b/queue/memory_test.go
@@ -17,6 +17,7 @@ type MemorySuite struct {
 
 func (s *MemorySuite) SetupSuite() {
 	s.BrokerURI = testMemoryURI
+	s.AdvWindowNotSupported = true
 }
 
 func (s *MemorySuite) TestIntegration() {


### PR DESCRIPTION
You can do a `PublishDelayed`, so it does not make any sense that it returns an `io.EOF`