### PR TITLE
Update uuid.NewV4 call to use newer version

### DIFF
--- a/queue/amqp.go
+++ b/queue/amqp.go
@@ -418,7 +418,7 @@ func (i *AMQPJobIter) Next() (*Job, error) {
 		return nil, ErrAlreadyClosed
 	}
 
-	return fromDelivery(&d), nil
+	return fromDelivery(&d)
 }
 
 func (i *AMQPJobIter) nextNonBlocking() (*Job, error) {
@@ -428,7 +428,7 @@ func (i *AMQPJobIter) nextNonBlocking() (*Job, error) {
 			return nil, ErrAlreadyClosed
 		}
 
-		return fromDelivery(&d), nil
+		return fromDelivery(&d)
 	default:
 		return nil, nil
 	}
@@ -460,8 +460,12 @@ func (a *AMQPAcknowledger) Reject(requeue bool) error {
 	return a.ack.Reject(a.id, requeue)
 }
 
-func fromDelivery(d *amqp.Delivery) *Job {
-	j := NewJob()
+func fromDelivery(d *amqp.Delivery) (*Job, error) {
+	j, err := NewJob()
+	if err != nil {
+		return nil, err
+	}
+
 	j.ID = d.MessageId
 	j.Priority = Priority(d.Priority)
 	j.Timestamp = d.Timestamp
@@ -470,5 +474,5 @@ func fromDelivery(d *amqp.Delivery) *Job {
 	j.tag = d.DeliveryTag
 	j.raw = d.Body
 
-	return j
+	return j, nil
 }

--- a/queue/common_test.go
+++ b/queue/common_test.go
@@ -118,7 +118,9 @@ func (s *QueueSuite) TestJob_Reject_no_requeue() {
 	assert.NoError(err)
 	assert.NotNil(q)
 
-	j := NewJob()
+	j, err := NewJob()
+	assert.NoError(err)
+
 	err = j.Encode(1)
 	assert.NoError(err)
 
@@ -158,7 +160,9 @@ func (s *QueueSuite) TestJob_Reject_requeue() {
 	assert.NoError(err)
 	assert.NotNil(q)
 
-	j := NewJob()
+	j, err := NewJob()
+	assert.NoError(err)
+
 	err = j.Encode(1)
 	assert.NoError(err)
 
@@ -246,7 +250,8 @@ func (s *QueueSuite) TestPublishAndConsume_immediate_ack() {
 		timestamps []time.Time
 	)
 	for i := 0; i < 100; i++ {
-		j := NewJob()
+		j, err := NewJob()
+		assert.NoError(err)
 		err = j.Encode(i)
 		assert.NoError(err)
 		err = q.Publish(j)
@@ -331,8 +336,9 @@ func (s *QueueSuite) newQueueWithJobs(n int) Queue {
 	assert.NoError(err)
 
 	for i := 0; i < n; i++ {
-		job := NewJob()
-		err := job.Encode(i)
+		job, err := NewJob()
+		assert.NoError(err)
+		err = job.Encode(i)
 		assert.NoError(err)
 		err = queue.Publish(job)
 		assert.NoError(err)
@@ -349,7 +355,8 @@ func (s *QueueSuite) TestDelayed() {
 	assert.NoError(err)
 	assert.NotNil(q)
 
-	j := NewJob()
+	j, err := NewJob()
+	assert.NoError(err)
 	err = j.Encode("hello")
 	assert.NoError(err)
 	err = q.PublishDelayed(j, 1*time.Second)
@@ -393,7 +400,8 @@ func (s *QueueSuite) TestTransaction_Error() {
 	assert.NotNil(q)
 
 	err = q.Transaction(func(qu Queue) error {
-		job := NewJob()
+		job, err := NewJob()
+		assert.NoError(err)
 		assert.NoError(job.Encode("goodbye"))
 		assert.NoError(qu.Publish(job))
 		return errors.New("foo")
@@ -429,7 +437,8 @@ func (s *QueueSuite) TestTransaction() {
 	assert.NotNil(q)
 
 	err = q.Transaction(func(q Queue) error {
-		job := NewJob()
+		job, err := NewJob()
+		assert.NoError(err)
 		assert.NoError(job.Encode("hello"))
 		assert.NoError(q.Publish(job))
 		return nil
@@ -473,14 +482,16 @@ func (s *QueueSuite) TestRetryQueue() {
 	assert.NotNil(q)
 
 	// 1: Publish jobs to the main queue.
-	j1 := NewJob()
+	j1, err := NewJob()
+	assert.NoError(err)
 	err = j1.Encode(1)
 	assert.NoError(err)
 
 	err = q.Publish(j1)
 	assert.NoError(err)
 
-	j2 := NewJob()
+	j2, err := NewJob()
+	assert.NoError(err)
 	err = j2.Encode(2)
 	assert.NoError(err)
 	err = q.Publish(j2)

--- a/queue/job.go
+++ b/queue/job.go
@@ -44,7 +44,6 @@ type Acknowledger interface {
 // timestamp.
 func NewJob() *Job {
 	u, err := uuid.NewV4()
-
 	if err != nil {
 		return nil
 	}

--- a/queue/job.go
+++ b/queue/job.go
@@ -43,8 +43,14 @@ type Acknowledger interface {
 // NewJob creates a new Job with default values, a new unique ID and current
 // timestamp.
 func NewJob() *Job {
+	u, err := uuid.NewV4()
+
+	if err != nil {
+		return nil
+	}
+
 	return &Job{
-		ID:          uuid.NewV4().String(),
+		ID:          u.String(),
 		Priority:    PriorityNormal,
 		Timestamp:   time.Now(),
 		contentType: msgpackContentType,

--- a/queue/job.go
+++ b/queue/job.go
@@ -42,10 +42,10 @@ type Acknowledger interface {
 
 // NewJob creates a new Job with default values, a new unique ID and current
 // timestamp.
-func NewJob() *Job {
+func NewJob() (*Job, error) {
 	u, err := uuid.NewV4()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	return &Job{
@@ -53,7 +53,7 @@ func NewJob() *Job {
 		Priority:    PriorityNormal,
 		Timestamp:   time.Now(),
 		contentType: msgpackContentType,
-	}
+	}, nil
 }
 
 // Encode encodes the payload to the wire format used.

--- a/queue/memory_test.go
+++ b/queue/memory_test.go
@@ -28,13 +28,17 @@ func (s *MemorySuite) TestIntegration() {
 	assert.NoError(err)
 	assert.NotNil(q)
 
-	j := NewJob()
+	j, err := NewJob()
+	assert.NoError(err)
+
 	j.Encode(true)
 	err = q.Publish(j)
 	assert.NoError(err)
 
 	for i := 0; i < 100; i++ {
-		job := NewJob()
+		job, err := NewJob()
+		assert.NoError(err)
+
 		job.Encode(true)
 		err = q.Publish(job)
 		assert.NoError(err)


### PR DESCRIPTION
There is no way to pass the error message when creating a new Job. It returns a nil Job if it happens.
