### PR TITLE
Move errors to src-d/go-errors

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"gopkg.in/src-d/framework.v0/configurable"
-	errors "gopkg.in/src-d/go-errors.v1"
+	"gopkg.in/src-d/go-errors.v1"
 
 	_ "github.com/lib/pq"
 )

--- a/database/database.go
+++ b/database/database.go
@@ -2,12 +2,13 @@ package database
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"time"
 
-	_ "github.com/lib/pq"
 	"gopkg.in/src-d/framework.v0/configurable"
+	errors "gopkg.in/src-d/go-errors.v1"
+
+	_ "github.com/lib/pq"
 )
 
 // DatabaseConfig describes the configuration of the database parameters used
@@ -112,14 +113,14 @@ var DefaultConfig = new(DatabaseConfig)
 
 // ErrNoConfig is returned when there is an attempt of getting a databsse
 // connection with no configuration.
-var ErrNoConfig = errors.New("database: can't get database with no configuration")
+var ErrNoConfig = errors.NewKind("database: can't get database with no configuration")
 
 // Get returns a database connection with the configuration resultant of
 // applying the given configfuncs to the config.
 // Passing a nil configuration will result in an error.
 func Get(config *DatabaseConfig, configurators ...ConfigFunc) (*sql.DB, error) {
 	if config == nil {
-		return nil, ErrNoConfig
+		return nil, ErrNoConfig.New()
 	}
 
 	for _, c := range configurators {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -129,7 +129,7 @@ func TestGet(t *testing.T) {
 	require := require.New(t)
 
 	_, err := Get(nil)
-	require.Equal(ErrNoConfig, err)
+	require.EqualError(ErrNoConfig.New(), err.Error())
 
 	db, err := Get(DefaultConfig)
 	require.Nil(err)

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -129,7 +129,7 @@ func TestGet(t *testing.T) {
 	require := require.New(t)
 
 	_, err := Get(nil)
-	require.EqualError(ErrNoConfig.New(), err.Error())
+	require.True(ErrNoConfig.Is(err))
 
 	db, err := Get(DefaultConfig)
 	require.Nil(err)

--- a/queue/amqp.go
+++ b/queue/amqp.go
@@ -219,7 +219,7 @@ type AMQPQueue struct {
 // Publish publishes the given Job to the Queue.
 func (q *AMQPQueue) Publish(j *Job) error {
 	if j == nil || len(j.raw) == 0 {
-		return ErrEmptyJob
+		return ErrEmptyJob.New()
 	}
 
 	headers := amqp.Table{}
@@ -252,7 +252,7 @@ func (q *AMQPQueue) Publish(j *Job) error {
 // wont go into the buried queue if they fail.
 func (q *AMQPQueue) PublishDelayed(j *Job, delay time.Duration) error {
 	if j == nil || len(j.raw) == 0 {
-		return ErrEmptyJob
+		return ErrEmptyJob.New()
 	}
 
 	ttl := delay / time.Millisecond
@@ -457,7 +457,7 @@ type AMQPJobIter struct {
 func (i *AMQPJobIter) Next() (*Job, error) {
 	d, ok := <-i.c
 	if !ok {
-		return nil, ErrAlreadyClosed
+		return nil, ErrAlreadyClosed.New()
 	}
 
 	return fromDelivery(&d)
@@ -467,7 +467,7 @@ func (i *AMQPJobIter) nextNonBlocking() (*Job, error) {
 	select {
 	case d, ok := <-i.c:
 		if !ok {
-			return nil, ErrAlreadyClosed
+			return nil, ErrAlreadyClosed.New()
 		}
 
 		return fromDelivery(&d)

--- a/queue/amqp.go
+++ b/queue/amqp.go
@@ -8,9 +8,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"gopkg.in/src-d/go-errors.v1"
+
 	"github.com/streadway/amqp"
 	log15 "gopkg.in/inconshreveable/log15.v2"
-	errors "gopkg.in/src-d/go-errors.v1"
 )
 
 var consumerSeq uint64

--- a/queue/common.go
+++ b/queue/common.go
@@ -1,10 +1,11 @@
 package queue
 
 import (
-	"errors"
 	"io"
 	"net/url"
 	"time"
+
+	errors "gopkg.in/src-d/go-errors.v1"
 )
 
 // Priority represents a priority level.
@@ -22,15 +23,15 @@ const (
 var (
 	// ErrAlreadyClosed is the error returned when trying to close an already closed
 	// connection.
-	ErrAlreadyClosed = errors.New("already closed")
+	ErrAlreadyClosed = errors.NewKind("already closed")
 	// ErrEmptyJob is the error returned when an empty job is published.
-	ErrEmptyJob = errors.New("invalid empty job")
+	ErrEmptyJob = errors.NewKind("invalid empty job")
 	// ErrTxNotSupported is the error returned when the transaction receives a
 	// callback does not know how to handle.
-	ErrTxNotSupported = errors.New("transactions not supported")
+	ErrTxNotSupported = errors.NewKind("transactions not supported")
 	// ErrUnsupportedProtocol is the error returned when a Broker does not know how
 	// to connect to a given URL
-	ErrUnsupportedProtocol = errors.New("unsupported protocol")
+	ErrUnsupportedProtocol = errors.NewKind("unsupported protocol")
 )
 
 const (
@@ -61,7 +62,7 @@ func NewBroker(uri string) (Broker, error) {
 	case protoMemory:
 		return NewMemoryBroker(), nil
 	default:
-		return nil, ErrUnsupportedProtocol
+		return nil, ErrUnsupportedProtocol.New()
 	}
 }
 

--- a/queue/common.go
+++ b/queue/common.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"time"
 
-	errors "gopkg.in/src-d/go-errors.v1"
+	"gopkg.in/src-d/go-errors.v1"
 )
 
 // Priority represents a priority level.

--- a/queue/common_test.go
+++ b/queue/common_test.go
@@ -49,7 +49,7 @@ func TestNewBroker(t *testing.T) {
 	assert.NoError(b.Close())
 
 	b, err = NewBroker("badproto://badurl")
-	assert.EqualError(ErrUnsupportedProtocol.New(), err.Error())
+	assert.True(ErrUnsupportedProtocol.Is(err))
 
 	b, err = NewBroker("foo://host%10")
 	assert.Error(err)
@@ -197,7 +197,7 @@ func (s *QueueSuite) TestPublish_nil() {
 	assert.NotNil(q)
 
 	err = q.Publish(nil)
-	assert.EqualError(ErrEmptyJob.New(), err.Error())
+	assert.True(ErrEmptyJob.Is(err))
 }
 
 func (s *QueueSuite) TestPublish_empty() {
@@ -209,7 +209,7 @@ func (s *QueueSuite) TestPublish_empty() {
 	assert.NotNil(q)
 
 	err = q.Publish(&Job{})
-	assert.EqualError(ErrEmptyJob.New(), err.Error())
+	assert.True(ErrEmptyJob.Is(err))
 }
 
 func (s *QueueSuite) TestPublishDelayed_nil() {
@@ -221,7 +221,7 @@ func (s *QueueSuite) TestPublishDelayed_nil() {
 	assert.NotNil(q)
 
 	err = q.PublishDelayed(nil, time.Second)
-	assert.EqualError(ErrEmptyJob.New(), err.Error())
+	assert.True(ErrEmptyJob.Is(err))
 }
 
 func (s *QueueSuite) TestPublishDelayed_empty() {
@@ -233,7 +233,7 @@ func (s *QueueSuite) TestPublishDelayed_empty() {
 	assert.NotNil(q)
 
 	err = q.PublishDelayed(&Job{}, time.Second)
-	assert.EqualError(ErrEmptyJob.New(), err.Error())
+	assert.True(ErrEmptyJob.Is(err))
 }
 
 func (s *QueueSuite) TestPublishAndConsume_immediate_ack() {
@@ -470,7 +470,7 @@ func (s *QueueSuite) TestTransaction_not_supported() {
 	assert.NotNil(q)
 
 	err = q.Transaction(nil)
-	assert.EqualError(ErrTxNotSupported.New(), err.Error())
+	assert.True(ErrTxNotSupported.Is(err))
 }
 
 func (s *QueueSuite) TestRetryQueue() {
@@ -544,7 +544,7 @@ func (s *QueueSuite) checkNextClosed(iter JobIter) chan struct{} {
 	done := make(chan struct{})
 	go func() {
 		j, err := iter.Next()
-		assert.EqualError(ErrAlreadyClosed.New(), err.Error())
+		assert.True(ErrAlreadyClosed.Is(err))
 		assert.Nil(j)
 		done <- struct{}{}
 	}()

--- a/queue/common_test.go
+++ b/queue/common_test.go
@@ -49,7 +49,7 @@ func TestNewBroker(t *testing.T) {
 	assert.NoError(b.Close())
 
 	b, err = NewBroker("badproto://badurl")
-	assert.Equal(ErrUnsupportedProtocol, err)
+	assert.EqualError(ErrUnsupportedProtocol.New(), err.Error())
 
 	b, err = NewBroker("foo://host%10")
 	assert.Error(err)
@@ -197,7 +197,7 @@ func (s *QueueSuite) TestPublish_nil() {
 	assert.NotNil(q)
 
 	err = q.Publish(nil)
-	assert.Equal(ErrEmptyJob, err)
+	assert.EqualError(ErrEmptyJob.New(), err.Error())
 }
 
 func (s *QueueSuite) TestPublish_empty() {
@@ -209,7 +209,7 @@ func (s *QueueSuite) TestPublish_empty() {
 	assert.NotNil(q)
 
 	err = q.Publish(&Job{})
-	assert.Equal(ErrEmptyJob, err)
+	assert.EqualError(ErrEmptyJob.New(), err.Error())
 }
 
 func (s *QueueSuite) TestPublishDelayed_nil() {
@@ -221,7 +221,7 @@ func (s *QueueSuite) TestPublishDelayed_nil() {
 	assert.NotNil(q)
 
 	err = q.PublishDelayed(nil, time.Second)
-	assert.Equal(ErrEmptyJob, err)
+	assert.EqualError(ErrEmptyJob.New(), err.Error())
 }
 
 func (s *QueueSuite) TestPublishDelayed_empty() {
@@ -233,7 +233,7 @@ func (s *QueueSuite) TestPublishDelayed_empty() {
 	assert.NotNil(q)
 
 	err = q.PublishDelayed(&Job{}, time.Second)
-	assert.Equal(ErrEmptyJob, err)
+	assert.EqualError(ErrEmptyJob.New(), err.Error())
 }
 
 func (s *QueueSuite) TestPublishAndConsume_immediate_ack() {
@@ -470,7 +470,7 @@ func (s *QueueSuite) TestTransaction_not_supported() {
 	assert.NotNil(q)
 
 	err = q.Transaction(nil)
-	assert.Equal(ErrTxNotSupported, err)
+	assert.EqualError(ErrTxNotSupported.New(), err.Error())
 }
 
 func (s *QueueSuite) TestRetryQueue() {
@@ -544,7 +544,7 @@ func (s *QueueSuite) checkNextClosed(iter JobIter) chan struct{} {
 	done := make(chan struct{})
 	go func() {
 		j, err := iter.Next()
-		assert.Equal(ErrAlreadyClosed, err)
+		assert.EqualError(ErrAlreadyClosed.New(), err.Error())
 		assert.Nil(j)
 		done <- struct{}{}
 	}()

--- a/queue/job.go
+++ b/queue/job.go
@@ -1,9 +1,10 @@
 package queue
 
 import (
-	"errors"
 	"fmt"
 	"time"
+
+	errors "gopkg.in/src-d/go-errors.v1"
 
 	"github.com/satori/go.uuid"
 	"gopkg.in/vmihailenco/msgpack.v2"
@@ -81,12 +82,12 @@ func (j *Job) Decode(payload interface{}) error {
 	return decode(msgpackContentType, j.raw, &payload)
 }
 
-var errCantAck = errors.New("can't acknowledge this message, it does not come from a queue")
+var ErrCantAck = errors.NewKind("can't acknowledge this message, it does not come from a queue")
 
 // Ack is called when the job is finished.
 func (j *Job) Ack() error {
 	if j.acknowledger == nil {
-		return errCantAck
+		return ErrCantAck.New()
 	}
 	return j.acknowledger.Ack()
 }
@@ -95,7 +96,7 @@ func (j *Job) Ack() error {
 // job should be put back in the queue.
 func (j *Job) Reject(requeue bool) error {
 	if j.acknowledger == nil {
-		return errCantAck
+		return ErrCantAck.New()
 	}
 	return j.acknowledger.Reject(requeue)
 }

--- a/queue/job.go
+++ b/queue/job.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	errors "gopkg.in/src-d/go-errors.v1"
+	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/satori/go.uuid"
 	"gopkg.in/vmihailenco/msgpack.v2"

--- a/queue/memory.go
+++ b/queue/memory.go
@@ -39,7 +39,7 @@ type memoryQueue struct {
 // Publish publishes a Job to the queue.
 func (q *memoryQueue) Publish(j *Job) error {
 	if j == nil || len(j.raw) == 0 {
-		return ErrEmptyJob
+		return ErrEmptyJob.New()
 	}
 
 	q.Lock()
@@ -51,7 +51,7 @@ func (q *memoryQueue) Publish(j *Job) error {
 // PublishDelayed publishes a Job to the queue with a given delay.
 func (q *memoryQueue) PublishDelayed(j *Job, delay time.Duration) error {
 	if j == nil || len(j.raw) == 0 {
-		return ErrEmptyJob
+		return ErrEmptyJob.New()
 	}
 
 	if q.publishImmediately {
@@ -132,7 +132,7 @@ func (i *memoryJobIter) isClosed() bool {
 func (i *memoryJobIter) Next() (*Job, error) {
 	for {
 		if i.isClosed() {
-			return nil, ErrAlreadyClosed
+			return nil, ErrAlreadyClosed.New()
 		}
 
 		j, err := i.next()


### PR DESCRIPTION
Changed all standard errors to use `gopkg.in/src-d/go-errors.v1`

Signed-off-by: Manuel Carmona <manu.carmona90@gmail.com>